### PR TITLE
LIT-53 - Updates the Location API examples to use token

### DIFF
--- a/LocationAPI/AddLocation.js
+++ b/LocationAPI/AddLocation.js
@@ -1,6 +1,6 @@
 const xhr = new XMLHttpRequest();
 
-const userId = "ADD YOUR USER ID HERE";
+const token = "ADD YOUR TOKEN HERE";
 const locationName = "My Location Name";
 const customId = "my-custom-location-id";
 const latitude = 55.862669; // centrepoint or reference point of the location
@@ -41,14 +41,13 @@ const data = {
   "properties": {
     "latitude": latitude,
     "longitude": longitude,
-    "userId": userId,
     "locationName": locationName,
     "customId": customId,
     "products": products,
     "tags": tags,
   }
 }
-const url = `https://location-api.hibirdi.com/users/${userId}/locations`;
+const url = `https://location-api.hibirdi.com/users/${token}/locations`;
 
 xhr.addEventListener("readystatechange", function () {
   if (this.readyState === 4) {

--- a/LocationAPI/AddLocation.py
+++ b/LocationAPI/AddLocation.py
@@ -1,7 +1,7 @@
 import requests
 import json
 
-userId = "ADD YOUR USER ID HERE"
+token = "ADD YOUR TOKEN HERE"
 locationName = "My Location Name"
 customId = "my-custom-location-id"
 latitude = 55.862669 # centrepoint or reference point of the location
@@ -42,7 +42,6 @@ data = {
   "properties": {
     "latitude": latitude,
     "longitude": longitude,
-    "userId": userId,
     "locationName": locationName,
     "customId": customId,
     "products": products,
@@ -51,7 +50,7 @@ data = {
 }
 
 url = ("https://location-api.hibirdi.com/users/{}/locations"
-       .format(userId))
+       .format(token))
 headers = {"Content-Type": "application/json"}
 
 response = requests.request("POST", url, data=(json.dumps(data)), headers=headers)

--- a/LocationAPI/GetLocations.js
+++ b/LocationAPI/GetLocations.js
@@ -1,12 +1,12 @@
 let data = null;
 const xhr = new XMLHttpRequest();
 
-const userId = "ADD YOUR USER ID HERE";
+const token = "ADD YOUR TOKEN HERE";
 const page = 1;
 const itemsPerPage = 100;
 const customId = "my-custom-location-id";
 const type = "construction";
-const url = "https://location-api.hibirdi.com/users/" + userId +
+const url = "https://location-api.hibirdi.com/users/" + token +
             "/locations" +
             "?page=" + page +
             "&itemsPerPage=" + itemsPerPage +

--- a/LocationAPI/GetLocations.py
+++ b/LocationAPI/GetLocations.py
@@ -1,14 +1,14 @@
 import requests
 import json
 
-userId = "ADD YOUR USER ID HERE"
+token = "ADD YOUR TOKEN HERE"
 page = 1
 itemsPerPage = 100
 customId = "my-custom-location-id"
 type = "construction"
 
 url = ("https://location-api.hibirdi.com/users/{}/locations?page={}&itemsPerPage={}&customId={}&type={}"
-       .format(userId, page, itemsPerPage, customId, type))
+       .format(token, page, itemsPerPage, customId, type))
 
 response = requests.request("GET", url)
 

--- a/LocationAPI/UpdateLocation.js
+++ b/LocationAPI/UpdateLocation.js
@@ -1,52 +1,15 @@
 const xhr = new XMLHttpRequest();
 
 const locationId = "LOCATIONID OF LOCATION TO BE UPDATED";
-const userId = "ADD YOUR USER ID HERE";
 const locationName = "My Location Name";
 const customId = "my-custom-location-id";
-const latitude = 55.862669; // centrepoint or reference point of the location
-const longitude = -4.250593; //centrepoint or reference point of the location
 const products = ["nucd"]; // intelligence products the location will be subscribed to
-const tags = [{ "tag": "administrative", "value": "city" }]; // custom tags for the location
-const geometry = {
-  "type": "Polygon",
-  "coordinates": [
-      [
-          [
-              -4.261600,
-              55.868846
-          ],
-          [
-              -4.239585,
-              55.868846
-          ],
-          [
-              -4.239585,
-              55.856491
-          ],
-          [
-              -4.261600,
-              55.856491
-          ],
-          [
-              -4.261600,
-              55.868846
-          ]
-      ]
-  ]
-} // GeoJSON geometry
 
 const data = {
-  "type": "Feature",
-  "geometry": geometry,
   "properties": {
-    "latitude": latitude,
-    "longitude": longitude,
-    "userId": userId,
     "locationName": locationName,
     "customId": customId,
     "products": products,
-    "tags": tags,
   }
 }
 const url = `https://location-api.hibirdi.com/locations/${locationId}`;

--- a/LocationAPI/UpdateLocation.py
+++ b/LocationAPI/UpdateLocation.py
@@ -2,52 +2,15 @@ import requests
 import json
 
 locationId = "LOCATIONID OF LOCATION TO BE UPDATED"
-userId = "ADD YOUR USER ID HERE"
 locationName = "My Location Name"
 customId = "my-custom-location-id"
-latitude = 55.862669 # centrepoint or reference point of the location
-longitude = -4.250593 #centrepoint or reference point of the location
 products = ["nucd"] # intelligence products the location will be subscribed to
-tags = [{ "tag": "administrative", "value": "city" }] # custom tags for the location
-geometry = {
-  "type": "Polygon",
-  "coordinates": [
-      [
-          [
-              -4.261600,
-              55.868846
-          ],
-          [
-              -4.239585,
-              55.868846
-          ],
-          [
-              -4.239585,
-              55.856491
-          ],
-          [
-              -4.261600,
-              55.856491
-          ],
-          [
-              -4.261600,
-              55.868846
-          ]
-      ]
-  ]
-} # GeoJSON geometry
 
 data = {
-  "type": "Feature",
-  "geometry": geometry,
   "properties": {
-    "latitude": latitude,
-    "longitude": longitude,
-    "userId": userId,
     "locationName": locationName,
     "customId": customId,
     "products": products,
-    "tags": tags,
   }
 }
 


### PR DESCRIPTION

Updates to the Locations API request examples to use token instead of userId, and to simplify the `update location` request schema.
